### PR TITLE
Fixes for flightctl build and enrollment certificate request

### DIFF
--- a/builds/flightctl-cli/Containerfile
+++ b/builds/flightctl-cli/Containerfile
@@ -2,7 +2,7 @@ FROM registry.redhat.io/openshift4/ose-cli:latest
 
 USER 0
 
-RUN curl -L https://github.com/flightctl/flightctl/releases/latest/download/flightctl-linux-amd64 --output /usr/local/bin/flightctl
+RUN curl -L https://github.com/flightctl/flightctl/releases/download/v0.5.1/flightctl-linux-amd64 --output /usr/local/bin/flightctl
 
 RUN chmod +x /usr/local/bin/flightctl
 

--- a/charts/create-flightctl-agent-config/templates/job.yaml
+++ b/charts/create-flightctl-agent-config/templates/job.yaml
@@ -21,17 +21,26 @@ spec:
               cd /tmp
               FLIGHTCTL_USERNAME=$(cat /tmp/openshift-auth/username)
               FLIGHTCTL_PASSWORD=$(cat /tmp/openshift-auth/password)
+
+              # Wait for route to become available
               until FLIGHTCTL_API_URL=$(oc get route flightctl-api-route -n open-cluster-management -o go-template='{{ "{{" }}.spec.host{{ "}}" }}') && [ -n "$FLIGHTCTL_API_URL" ]; do
                 echo "Route not found, retrying in 5 seconds..."
                 sleep 5
               done
 
+              # Wait until login to flightctl works
               until flightctl login "https://$FLIGHTCTL_API_URL" --username "$FLIGHTCTL_USERNAME" --password "$FLIGHTCTL_PASSWORD" --insecure-skip-tls-verify; do
                 echo "Login failed, retrying in 5 seconds..."
                 sleep 5
               done
 
-              flightctl certificate request --signer=enrollment --expiration=365d --output=embedded > config.yaml
+              # Attempt to get certificate, and retry if unsuccessful
+              until flightctl certificate request --signer=enrollment --expiration=365d --output=embedded > config.yaml; do
+                echo "Certificate request failed, retrying in 5 seconds..."
+                sleep 5
+              done
+
+              # Add enrollment request and configs into a configMap that builds will use later
               echo '---
               apiVersion: v1
               kind: ConfigMap


### PR DESCRIPTION
1. Pin flightctl cli tool version
2. Add more protection logic around requesting enrollment certificates